### PR TITLE
Allow server to run for more than most-positive-fixnum seconds

### DIFF
--- a/example.lisp
+++ b/example.lisp
@@ -9,8 +9,13 @@
 
 (export 'main)
 (defun main ()
-  (let ((acceptor (make-instance
-                   'easy-acceptor
-                   :port (parse-integer (uiop:getenv "PORT")))))
+  (let* ((port (parse-integer (uiop:getenv "PORT")))
+         (acceptor (make-instance
+                    'easy-acceptor
+                    :port port)))
     (start acceptor)
-    (sleep most-positive-fixnum)))
+    (bt:join-thread
+     (find (format nil "hunchentoot-listener-*:~A" port)
+           (bt:all-threads)
+           :key #'bt:thread-name
+           :test #'string=))))


### PR DESCRIPTION
## Description
Join the main thread with the server thread so that server will stay up longer than some seconds.
The foreground thread will wait for the server thread to complete before returning.

I know this is just an example repository, but having a working example could be useful.

## Related Issue
This project only accepts pull requests related to open issues.
- If suggesting a new feature or change, please discuss it in an issue first
- If fixing a bug, there should be an issue describing it with steps to reproduce it following the bug report guide
- If you're suggesting a feature, please follow the feature request guide by clicking on issues

### Please drop a link to the issue here:
https://github.com/platformsh-templates/lisp/issues/8

## Motivation and Context
With `sleep`, the main thread (and thus the whole application) will terminate after the nap is finished.

## How Has This Been Tested?
I have used this snippet in my production servers and they would stay up for a very long time.

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
 Go over all the following list, and put an `x` in all the boxes that apply. If you're unsure about what any of these mean, don't hesitate to ask. We're here to help!

- [ ] I have read the contribution guide
- [X] I have created an issue following the issue guide
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
